### PR TITLE
Making the --remote feature optional

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -95,9 +95,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Proxy the original webhook request to the backend
-	log.Printf("Proxying webhook request to %s/%s\n", h.remoteUrl, req.URL)
-	h.proxy.ServeHTTP(w, req)
+	if h.remoteUrl != "" {
+		// Proxy the original webhook request to the backend
+		log.Printf("Proxying webhook request to %s/%s\n", h.remoteUrl, req.URL)
+		h.proxy.ServeHTTP(w, req)
+	}
 }
 
 func (h *Handler) updateOrCloneRepoMirror(repoUri string) error {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 	tlsPrivateKeyFile  = flag.String("tls-key", "proxy.key", "Path to the private key for the TLS certificate")
 
 	// Remote web server options
-	remoteUrl = flag.String("remote", "http://localhost:8080", "HTTP URL to forward incoming hooks to, upon successful mirroring")
+	remoteUrl = flag.String("remote", "", "HTTP URL to forward incoming hooks to, upon successful mirroring")
 
 	// Git options
 	mirrorPath = flag.String("mirror-path", "/tmp/mirror", "Directory to which git repositories should be mirrored")
@@ -53,7 +53,9 @@ func main() {
 
 	// Show some basic config info
 	log.Println("Git repositories will be mirrored to: ", *mirrorPath)
-	log.Println("Webhook requests will be forwarded to:", *remoteUrl)
+	if *remoteUrl != "" {
+		log.Println("Webhook requests will be forwarded to:", *remoteUrl)
+	}
 
 	// Start the listening web server
 	handler, err := NewHandler(*gitPath, *mirrorPath, *remoteUrl)


### PR DESCRIPTION
Sometimes the only thing you want is to mirror github in case it becomes unaccessable or simply down\maintenance. So the whole proxy feature is not required in this usecase
